### PR TITLE
Add CLI for code introspection

### DIFF
--- a/hyjinx/__init__.py
+++ b/hyjinx/__init__.py
@@ -153,5 +153,5 @@ hy.macros.require('hyjinx.macros', None, assignments='ALL', prefix='')
 
 # set the package version
 # the major.minor version simply match the assumed Hy version
-__version__ = "1.2.1"
+__version__ = "1.2.3"
 __version_info__ = __version__.split(".")

--- a/hyjinx/cli.hy
+++ b/hyjinx/cli.hy
@@ -1,0 +1,226 @@
+#!/usr/bin/env hy
+"
+CLI for Hy/Python code introspection.
+
+Commands:
+    hyjinx where <symbol>  - Print file:line for a symbol
+    hyjinx source <symbol> - Print source code with highlighting
+    hyjinx doc <symbol>    - Print docstring
+"
+
+(require hyrule [-> ->>])
+
+(import click)
+(import importlib)
+(import functools [reduce])
+(import hy [mangle])
+(import toolz [last])
+(import inspect [ismodule])
+(import pygments [highlight])
+(import pygments.lexers [get-lexer-by-name])
+(import pygments.formatters [TerminalFormatter])
+(import multimethod [multimethod])
+(import hyjinx.source [print-source get-source-details _get-lang-from-filename])
+(import hyjinx.hjx-inspect [getsource getsourcefile])
+
+
+(defn get-source-details-safe [obj]
+  "Get source details, handling modules and multimethods specially."
+  (try
+    (get-source-details obj)
+    (except [TypeError]
+      ;; Module, multimethod, or other object without source details
+      (cond
+        ;; Module
+        (ismodule obj)
+          (if (hasattr obj "__file__")
+            {"line" 1
+             "module" (getattr obj "__name__" "unknown")
+             "file" obj.__file__
+             "language" (_get-lang-from-filename obj.__file__)
+             "extension" (last (.split obj.__file__ "."))}
+            None)
+        ;; Multimethod
+        (isinstance obj multimethod)
+          (let [module-name (getattr obj "__module__" None)
+                obj-name (getattr obj "__name__" "unknown")]
+            (if module-name
+              (let [module (importlib.import-module module-name)]
+                {"line" 1
+                 "module" module-name
+                 "file" module.__file__
+                 "language" (_get-lang-from-filename module.__file__)
+                 "extension" (last (.split module.__file__ "."))})
+              None))
+        ;; Other object with __file__
+        (hasattr obj "__file__")
+          {"line" 1
+           "module" (getattr obj "__name__" "unknown")
+           "file" obj.__file__
+           "language" (_get-lang-from-filename obj.__file__)
+           "extension" (last (.split obj.__file__ "."))}
+        ;; Give up
+        True
+          None))))
+
+(defn resolve-symbol [symbol-path]
+  "Resolve a dotted symbol path to an object.
+  
+  Examples:
+    'agalmic.positions.db.get-position' 
+    -> import agalmic.positions.db, return get-position
+  "
+  (let [parts (.split symbol-path ".")]
+    (if (= (len parts) 1)
+      ;; Just a module name
+      (importlib.import-module symbol-path)
+      ;; Module + attributes
+      (do
+        ;; Try progressively longer module paths
+        ;; e.g. for 'a.b.c.d', try 'a', 'a.b', 'a.b.c' as modules
+        (setv module-idx None)
+        (for [i (range (len parts) 0 -1)]
+          (let [module-path (.join "." (cut parts 0 i))]
+            (try
+              (do
+                (importlib.import-module module-path)
+                (setv module-idx i)
+                (break))
+              (except [ImportError]
+                None))))
+        
+        (when (is module-idx None)
+          (raise (ImportError f"Cannot import any module from {symbol-path}")))
+        
+        ;; Import the module and walk the attribute chain
+        (let [module-path (.join "." (cut parts 0 module-idx))
+              module (importlib.import-module module-path)
+              attrs (list (map mangle (cut parts module-idx None)))]
+          ;; First try regular attributes
+          (setv obj module)
+          (for [attr attrs]
+            (setv obj (getattr obj attr None)))
+          ;; If not found, try macros
+          (if (is obj None)
+            (do
+              (setv macros (getattr module "_hy_macros" {}))
+              (if (in (last attrs) macros)
+                (get macros (last attrs))
+                (raise (AttributeError f"{module-path} has no attribute {(last attrs)}"))))
+            obj))))))
+
+
+(defn get-docstring [obj]
+  "Get the docstring for an object."
+  (or (getattr obj "__doc__" None) "No docstring available."))
+
+
+;; --- CLI Commands ---
+
+(defn [(click.group)]
+  cli [])
+
+
+(defn [(click.command)
+       (click.argument "symbol")
+       (click.option "--json" :is-flag True :help "Output as JSON")]
+  where [symbol json]
+  "Print the file and line number where SYMBOL is defined."
+  (try
+    (let [obj (resolve-symbol symbol)
+          details (get-source-details-safe obj)]
+      (if (is details None)
+        (do
+          (click.echo f"No source details available for: {symbol}" :err True)
+          (raise (SystemExit 1)))
+        (if json
+          (click.echo (hy.I.json.dumps details :indent 2))
+          (click.echo f"{(:file details)}:{(:line details)}"))))
+    (except [ImportError]
+      (click.echo f"Symbol not found: {symbol}" :err True)
+      (raise (SystemExit 1)))
+    (except [AttributeError]
+      (click.echo f"Attribute not found: {symbol}" :err True)
+      (raise (SystemExit 1)))
+    (except [[OSError TypeError]]
+      (click.echo f"No source available for: {symbol}" :err True)
+      (raise (SystemExit 1)))))
+
+(cli.add-command where)
+
+
+(defn [(click.command)
+       (click.argument "symbol")
+       (click.option "--no-highlight" :is-flag True :help "Disable syntax highlighting")
+       (click.option "--line-numbers" :is-flag True :default True :help "Show line numbers")
+       (click.option "--reformat" :is-flag True :help "Reformat with beautifhy")]
+  source [symbol no-highlight line-numbers reformat]
+  "Print the source code for SYMBOL."
+  (try
+    (let [obj (resolve-symbol symbol)]
+      (if no-highlight
+        ;; Just print raw source
+        (click.echo (getsource obj))
+        ;; Check if it's a module
+        (if (ismodule obj)
+          ;; For modules, print with basic highlighting
+          (let [file (getsourcefile obj)
+                lang (_get-lang-from-filename file)
+                source (getsource obj)
+                lexer (get-lexer-by-name lang)
+                formatter (TerminalFormatter :bg "dark" :stripall True)]
+            (click.echo f"{obj}")
+            (click.echo f"File {file}")
+            (click.echo)
+            (click.echo (highlight source lexer formatter)))
+          ;; For other objects, use print-source with options
+          (print-source obj 
+                        :linenos line-numbers 
+                        :reformat reformat))))
+    (except [ImportError]
+      (click.echo f"Symbol not found: {symbol}" :err True)
+      (raise (SystemExit 1)))
+    (except [AttributeError]
+      (click.echo f"Attribute not found: {symbol}" :err True)
+      (raise (SystemExit 1)))
+    (except [[OSError TypeError]]
+      (click.echo f"No source available for: {symbol}" :err True)
+      (raise (SystemExit 1)))))
+
+(cli.add-command source)
+
+
+(defn [(click.command)
+       (click.argument "symbol")
+       (click.option "--all" :is-flag True :help "Include function signature")]
+  doc [symbol all]
+  "Print the docstring for SYMBOL."
+  (try
+    (let [obj (resolve-symbol symbol)
+          docstring (get-docstring obj)]
+      (if all
+        (do
+          (click.echo f"{obj}")
+          (click.echo)
+          (click.echo docstring))
+        (click.echo docstring)))
+    (except [ImportError]
+      (click.echo f"Symbol not found: {symbol}" :err True)
+      (raise (SystemExit 1)))
+    (except [AttributeError]
+      (click.echo f"Attribute not found: {symbol}" :err True)
+      (raise (SystemExit 1)))
+    (except [[OSError TypeError]]
+      (click.echo f"No docstring available for: {symbol}" :err True)
+      (raise (SystemExit 1)))))
+
+(cli.add-command doc)
+
+
+(defn main []
+  "Entry point for the CLI."
+  (cli))
+
+
+(when (= __name__ "__main__")
+  (main))

--- a/hyjinx/cli.hy
+++ b/hyjinx/cli.hy
@@ -67,8 +67,8 @@ Commands:
   "Resolve a dotted symbol path to an object.
   
   Examples:
-    'agalmic.positions.db.get-position' 
-    -> import agalmic.positions.db, return get-position
+    'hyjinx.macros.defmethod' 
+    -> import hyjinx.macros, return defmethod macro
   "
   (let [parts (.split symbol-path ".")]
     (if (= (len parts) 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "ansi-escapes",
     "beautifhy>=1.1.4",
+    "click",
     "colorist",
     "hy>=1.2.0",
     "hyrule",
@@ -37,6 +38,9 @@ dependencies = [
     "python-magic",
     "toolz"
 ]
+
+[project.scripts]
+hyjinx = "hyjinx.cli:main"
 
 [project.optional-dependencies]
 zmq = ["ecdsa", "pyzmq", "zstandard", "msgpack"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,123 @@
+"""
+Tests for the hyjinx CLI.
+"""
+
+import subprocess
+import sys
+
+
+def run_cli(*args):
+    """Run the hyjinx CLI with given arguments."""
+    result = subprocess.run(
+        ["/home/node/.openclaw/venvs/trading/bin/hyjinx"] + list(args),
+        capture_output=True,
+        text=True,
+    )
+    return result
+
+
+class TestWhere:
+    """Tests for the 'where' command."""
+
+    def test_where_function(self):
+        """Test finding a function's location."""
+        result = run_cli("where", "json.dumps")
+        assert result.returncode == 0
+        assert "json" in result.stdout
+        assert ":" in result.stdout  # file:line format
+
+    def test_where_module(self):
+        """Test finding a module's location."""
+        result = run_cli("where", "hyjinx.macros")
+        assert result.returncode == 0
+        assert "macros.hy" in result.stdout
+
+    def test_where_macro(self):
+        """Test finding a macro's location."""
+        result = run_cli("where", "hyjinx.macros.defmethod")
+        assert result.returncode == 0
+        assert "macros.hy" in result.stdout
+
+    def test_where_multimethod(self):
+        """Test finding a multimethod's location."""
+        result = run_cli("where", "hyjinx.source.print-source")
+        assert result.returncode == 0
+        assert "source.hy" in result.stdout
+
+    def test_where_not_found(self):
+        """Test error for non-existent symbol."""
+        result = run_cli("where", "nonexistent.module")
+        assert result.returncode == 1
+        assert "not found" in result.stderr.lower() or "not found" in result.stdout.lower()
+
+    def test_where_json_output(self):
+        """Test JSON output format."""
+        result = run_cli("where", "json.dumps", "--json")
+        assert result.returncode == 0
+        import json
+        data = json.loads(result.stdout)
+        assert "file" in data
+        assert "line" in data
+        assert "module" in data
+
+
+class TestSource:
+    """Tests for the 'source' command."""
+
+    def test_source_function(self):
+        """Test showing a function's source."""
+        result = run_cli("source", "hyjinx.source.get-source-details")
+        assert result.returncode == 0
+        assert "defn" in result.stdout or "get_source_details" in result.stdout
+
+    def test_source_module(self):
+        """Test showing a module's source."""
+        result = run_cli("source", "hyjinx.macros")
+        assert result.returncode == 0
+        assert "defmacro" in result.stdout or "macros" in result.stdout
+
+    def test_source_macro(self):
+        """Test showing a macro's source."""
+        result = run_cli("source", "hyjinx.macros.defmethod")
+        assert result.returncode == 0
+        assert "defmacro" in result.stdout
+
+    def test_source_multimethod(self):
+        """Test showing a multimethod's source."""
+        result = run_cli("source", "hyjinx.source.print-source")
+        assert result.returncode == 0
+        assert "defmethod" in result.stdout or "print_source" in result.stdout
+
+    def test_source_not_found(self):
+        """Test error for non-existent symbol."""
+        result = run_cli("source", "nonexistent.module")
+        assert result.returncode == 1
+        assert "not found" in result.stderr.lower() or "not found" in result.stdout.lower()
+
+
+class TestDoc:
+    """Tests for the 'doc' command."""
+
+    def test_doc_function(self):
+        """Test showing a function's docstring."""
+        result = run_cli("doc", "hyjinx.source.get-source-details")
+        assert result.returncode == 0
+        assert "dict" in result.stdout.lower() or "line" in result.stdout.lower()
+
+    def test_doc_module(self):
+        """Test showing a module's docstring."""
+        result = run_cli("doc", "hyjinx.macros")
+        assert result.returncode == 0
+        assert "macros" in result.stdout.lower()
+
+    def test_doc_macro(self):
+        """Test showing a macro's docstring."""
+        result = run_cli("doc", "hyjinx.macros.defmethod")
+        assert result.returncode == 0
+        assert "multimethod" in result.stdout.lower()
+
+    def test_doc_not_found(self):
+        """Test error for non-existent symbol."""
+        result = run_cli("doc", "nonexistent.module")
+        assert result.returncode == 1
+        assert "not found" in result.stderr.lower() or "not found" in result.stdout.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ import sys
 def run_cli(*args):
     """Run the hyjinx CLI with given arguments."""
     result = subprocess.run(
-        ["/home/node/.openclaw/venvs/trading/bin/hyjinx"] + list(args),
+        [sys.executable, "-m", "hyjinx.cli"] + list(args),
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Summary

Adds a CLI tool for Hy/Python code introspection:

- `hyjinx where <symbol>` - Print file:line for a symbol
- `hyjinx source <symbol>` - Print source code with syntax highlighting  
- `hyjinx doc <symbol>` - Print docstring

Supports modules, functions, macros, and multimethods.

## Usage

```bash
$ hyjinx where hyjinx.macros.defmethod
/home/.../hyjinx/macros.hy:94

$ hyjinx source hyjinx.macros.defmethod
<function defmethod at 0x...>, module hyjinx.macros
File .../macros.hy, line 94
0095: (defmacro defmethod [#* args]
...

$ hyjinx doc hyjinx.macros.defmethod
Define a multimethod (using multimethod.multimethod).
```

## Changes

- Add `hyjinx/cli.hy` with three commands
- Add click dependency and console script entry point
- Handle modules, macros, and multimethods specially
- Add 15 tests for CLI functionality
- Bump version to 1.2.3

## Tests

All 117 tests pass (102 existing + 15 new).