### PR TITLE
Fix defcontext, coroutine, screen.hy; add crypto+defcontext+coroutine tests

### DIFF
--- a/hyjinx/lib.hy
+++ b/hyjinx/lib.hy
@@ -62,16 +62,12 @@ See individual function docstrings for detailed information.
     coroutine
     (asyncio.get-event-loop)))
 
-;; FIXME doesn't work
-(defn :async coroutine [f [process False] #* args #** kwargs]
-  "Decorator to run a synchronous function in an executor.
-  Defaults to `ThreadPoolExecutor`, more suitable for IO-bound tasks,
-  otherwise when `process` is `True`, uses `ProcessPoolExecutor`, for CPU-bound tasks.
-  Remember that the GIL exists."
-  (import asyncio [get-event-loop])
-  (import concurrent.futures [ProcessPoolExecutor ThreadPoolExecutor])
-  (with [executor (if process (ProcessPoolExecutor) (ThreadPoolExecutor))]
-    (await (.run-in-executor (get-event-loop) executor f #* args #** kwargs)))) 
+(defn :async coroutine [f #* args #** kwargs]
+  "Run a synchronous function in a thread executor.
+  A convenience wrapper around `asyncio.to-thread`.
+  The function `f` is called with `args` and `kwargs` in a thread pool."
+  (import asyncio)
+  (await (asyncio.to-thread f #* args #** kwargs))) 
 
 
 ;; * Functions

--- a/hyjinx/macros.hy
+++ b/hyjinx/macros.hy
@@ -123,21 +123,17 @@ Macros for Flow Control
          ~@body))))
 
 (defmacro defcontext [f #* body]
-  "Make a function a context manager.
-
-  Make function `f` a context manager using contextlib's
+  "Make a function a context manager using contextlib's
   `contextmanager` decorator."
-  (if (= :async (first args))
+  (if (= :async f)
 
-    (let [f (second args)
-          body (cut args 2 None)]
-      `(defn :async [hy.I.contextlib.asynccontextmanager] ~f
-         ~@body))
+    (let [fname (first body)
+          fbody (cut body 1 None)]
+      `(defn :async [hy.I.contextlib.asynccontextmanager] ~fname
+         ~@fbody))
 
-    (let [f (first args)
-          body (cut args 1 None)]
-      `(defn [hy.I.contextlib.contextmanager] ~f
-         ~@body))))
+    `(defn [hy.I.contextlib.contextmanager] ~f
+       ~@body)))
 
 (defmacro defproperty [f #* body]
   "Class method definition using the property decorator.

--- a/hyjinx/screen.hy
+++ b/hyjinx/screen.hy
@@ -1,5 +1,15 @@
-"A simple curses display class with context manager.
-You'll need to start the main using (.wrapper curses ...)."
+"""
+A simple ncurses display class with context manager support.
+
+Provides a `Screen` class that wraps curses for terminal-based UI.
+Start the main entry point with `.wrapper curses ...`.
+
+Features:
+  - Colour pair initialisation with default terminal colours
+  - Buffered message queues (warnings, errors, info, debug)
+  - Text input via embedded textbox
+  - Positioned string output with colour and style
+"""
 
 (require hyrule [unless -> ->>])
 

--- a/tests/native_tests/crypto.hy
+++ b/tests/native_tests/crypto.hy
@@ -1,0 +1,134 @@
+"
+Tests for hyjinx.crypto — ECDSA signing, verification, and password hashing.
+"
+
+(import time [time])
+(import hyjinx.crypto)
+
+
+;; ── Key derivation ────────────────────────────────────────────────────────────
+
+(defn test-signing-key-returns-signing-key []
+  (let [sk (hyjinx.crypto.signing-key "passphrase" "salt123")]
+    (assert (isinstance sk hyjinx.crypto.SigningKey))))
+
+(defn test-signing-key-deterministic []
+  (let [sk1 (hyjinx.crypto.signing-key "passphrase" "salt123")
+        sk2 (hyjinx.crypto.signing-key "passphrase" "salt123")]
+    (assert (= (.to-string sk1) (.to-string sk2)))))
+
+(defn test-signing-key-different-salts []
+  (let [sk1 (hyjinx.crypto.signing-key "passphrase" "salt1")
+        sk2 (hyjinx.crypto.signing-key "passphrase" "salt2")]
+    (assert (!= (.to-string sk1) (.to-string sk2)))))
+
+
+;; ── Keys ──────────────────────────────────────────────────────────────────────
+
+(defn test-keys-returns-dict []
+  (let [ks (hyjinx.crypto.keys "passphrase" "salt123")]
+    (assert (isinstance ks dict))
+    (assert (in "private" ks))
+    (assert (in "private_pem" ks))
+    (assert (in "public_pem" ks))))
+
+(defn test-keys-private-is-signing-key []
+  (let [ks (hyjinx.crypto.keys "passphrase" "salt123")]
+    (assert (isinstance (:private ks) hyjinx.crypto.SigningKey))))
+
+(defn test-keys-pem-are-strings []
+  (let [ks (hyjinx.crypto.keys "passphrase" "salt123")]
+    (assert (isinstance (:private_pem ks) str))
+    (assert (isinstance (:public_pem ks) str))))
+
+(defn test-keys-pem-starts-with-headers []
+  (let [ks (hyjinx.crypto.keys "passphrase" "salt123")]
+    (assert (.startswith (:private_pem ks) "-----BEGIN"))
+    (assert (.startswith (:public_pem ks) "-----BEGIN"))))
+
+
+;; ── Sign and verify ───────────────────────────────────────────────────────────
+
+(defn test-sign-returns-string []
+  (let [sk (hyjinx.crypto.signing-key "passphrase" "salt123")
+        sig (hyjinx.crypto.sign sk "hello")]
+    (assert (isinstance sig str))))
+
+(defn test-sign-verify-roundtrip []
+  (let [ks (hyjinx.crypto.keys "passphrase" "salt123")
+        sig (hyjinx.crypto.sign (:private ks) "test message")]
+    (assert (hyjinx.crypto.verify (:public_pem ks) sig "test message"))))
+
+(defn test-verify-rejects-tampered-message []
+  (let [ks (hyjinx.crypto.keys "passphrase" "salt123")
+        sig (hyjinx.crypto.sign (:private ks) "original")]
+    (assert (not (hyjinx.crypto.verify (:public_pem ks) sig "tampered")))))
+
+(defn test-verify-rejects-wrong-key []
+  (let [ks1 (hyjinx.crypto.keys "pass1" "salt1")
+        ks2 (hyjinx.crypto.keys "pass2" "salt2")
+        sig (hyjinx.crypto.sign (:private ks1) "message")]
+    (assert (not (hyjinx.crypto.verify (:public_pem ks2) sig "message")))))
+
+(defn test-sign-different-messages-different-signatures []
+  (let [sk (hyjinx.crypto.signing-key "passphrase" "salt123")
+        sig1 (hyjinx.crypto.sign sk "message one")
+        sig2 (hyjinx.crypto.sign sk "message two")]
+    (assert (!= sig1 sig2))))
+
+
+;; ── is-recent ─────────────────────────────────────────────────────────────────
+
+(defn test-is-recent-with-current-time []
+  (assert (hyjinx.crypto.is-recent (time))))
+
+(defn test-is-recent-with-old-time []
+  (assert (not (hyjinx.crypto.is-recent (- (time) 60)))))
+
+(defn test-is-recent-custom-threshold []
+  (assert (hyjinx.crypto.is-recent (- (time) 20) :threshold 30.0))
+  (assert (not (hyjinx.crypto.is-recent (- (time) 40) :threshold 30.0))))
+
+(defn test-is-recent-invalid-input []
+  ;; defmethod dispatches on float, so non-float raises DispatchError
+  (import multimethod [DispatchError])
+  (try
+    (hyjinx.crypto.is-recent None)
+    (assert False "should have raised")
+    (except [DispatchError]
+      (assert True))))
+
+
+;; ── Password hashing ──────────────────────────────────────────────────────────
+
+(defn test-hash-pw-returns-dict []
+  (let [result (hyjinx.crypto.hash-pw "secret")]
+    (assert (isinstance result dict))
+    (assert (in "salt" result))
+    (assert (in "hexdigest" result))))
+
+(defn test-hash-pw-salt-is-hex []
+  (let [result (hyjinx.crypto.hash-pw "secret")]
+    ;; 32 bytes = 64 hex chars
+    (assert (= (len (:salt result)) 64))))
+
+(defn test-hash-pw-different-salts []
+  (let [h1 (hyjinx.crypto.hash-pw "secret")
+        h2 (hyjinx.crypto.hash-pw "secret")]
+    (assert (!= (:salt h1) (:salt h2)))
+    (assert (!= (:hexdigest h1) (:hexdigest h2)))))
+
+(defn test-check-pw-correct []
+  (let [stored (hyjinx.crypto.hash-pw "correct-password")]
+    (assert (hyjinx.crypto.check-pw "correct-password" stored))))
+
+(defn test-check-pw-wrong []
+  (let [stored (hyjinx.crypto.hash-pw "correct-password")]
+    (assert (not (hyjinx.crypto.check-pw "wrong-password" stored)))))
+
+(defn test-check-pw-different-hashes-same-password []
+  (let [stored1 (hyjinx.crypto.hash-pw "same-password")
+        stored2 (hyjinx.crypto.hash-pw "same-password")]
+    ;; Different salts but both should verify
+    (assert (hyjinx.crypto.check-pw "same-password" stored1))
+    (assert (hyjinx.crypto.check-pw "same-password" stored2))))

--- a/tests/native_tests/lib.hy
+++ b/tests/native_tests/lib.hy
@@ -225,3 +225,25 @@ Tests for hyjinx.lib — the utility function library.
     (assert (get r "ok"))
     (let [data (unwrap r)]
       (assert (= (get (get data "a") "b") [1 2])))))
+
+
+;; ── coroutine ────────────────────────────────────────────────────────────────
+
+(import asyncio)
+
+(defn test-coroutine-runs-sync-in-thread []
+  (let [result (asyncio.run (hyjinx.lib.coroutine (fn [] 42)))]
+    (assert (= result 42))))
+
+(defn test-coroutine-with-args []
+  (let [result (asyncio.run (hyjinx.lib.coroutine (fn [x y] (+ x y)) 3 4))]
+    (assert (= result 7))))
+
+(defn test-coroutine-with-kwargs []
+  (let [result (asyncio.run (hyjinx.lib.coroutine (fn [x [y 10]] (+ x y)) 5 :y 20))]
+    (assert (= result 25))))
+
+(defn test-coroutine-blocking-io []
+  ;; Verify it actually runs in a thread (not blocking the event loop)
+  (let [result (asyncio.run (hyjinx.lib.coroutine (fn [] (import time) (time.sleep 0.01) "done")))]
+    (assert (= result "done"))))

--- a/tests/native_tests/macros.hy
+++ b/tests/native_tests/macros.hy
@@ -159,3 +159,44 @@ counter")]
   (setv n (+ n 1)))
 n")]
     (assert (= result 3))))
+
+
+;; ── defcontext ────────────────────────────────────────────────────────────────
+
+(defn test-defcontext-sync []
+  (let [result (hy-eval "
+(defcontext my-ctx [x]
+  (yield (* x 2)))
+(with [c (my-ctx 5)]
+  c)")]
+    (assert (= result 10))))
+
+(defn test-defcontext-async []
+  ;; Verify the :async variant produces an async context manager
+  (let [result (hy-eval "
+(import contextlib)
+(defcontext :async my-actx [x]
+  (yield (* x 3)))
+(isinstance (my-actx 4) contextlib._AsyncGeneratorContextManager)")]
+    (assert result)))
+
+(defn test-defcontext-is-contextmanager []
+  (let [result (hy-eval "
+(import contextlib)
+(defcontext ctest [v]
+  (yield v))
+(isinstance (ctest 1) contextlib._GeneratorContextManager)")]
+    (assert result)))
+
+(defn test-defcontext-cleanup-runs []
+  ;; After yield, cleanup code runs (contextmanager protocol)
+  ;; Use a list (mutable) so the generator can signal from inside
+  (let [result (hy-eval "
+(setv state [False])
+(defcontext cleanup-ctx []
+  (yield 42)
+  (setv (get state 0) True))
+(with [c (cleanup-ctx)]
+  c)
+(get state 0)")]
+    (assert result)))


### PR DESCRIPTION
## Fixes

- **defcontext macro**: Fixed undefined `args` variable — copy-paste error from `defmethod`. Now correctly uses `f`/`body` parameters.
- **coroutine function**: Was broken — `process` parameter sat between `f` and `#* args`, so positional args filled `process` instead of being passed to `f`. Simplified to a thin `asyncio.to-thread` wrapper; dropped the broken `process=True` ProcessPoolExecutor path (fundamental pickle limitations).
- **screen.hy**: Added module-level docstring with feature summary.

## New Tests

- **defcontext**: 4 tests (sync context manager, async isinstance, _GeneratorContextManager isinstance, cleanup code runs)
- **coroutine**: 4 tests (basic, with args, with kwargs, blocking I/O in thread)
- **crypto**: 20 tests (signing-key derivation, keys structure, sign/verify roundtrip, tampered message, wrong key, is-recent, hash-pw/check-pw roundtrip, different salts)