### PR TITLE
feat: add defmethod support to hyjinx dir

### DIFF
--- a/hyjinx/api.hy
+++ b/hyjinx/api.hy
@@ -61,8 +61,10 @@ This avoids triggering top-level code, DB connections, GPU init, etc.
     names))
 
 (defn _parse-defn [form]
-  "Parse a defn form, handling :async, decorators."
-  (let [idx 1]
+  "Parse a defn/defmethod form, handling :async, decorators."
+  (let [head (get form 0)
+        kind (if (= (str head) "defmethod") "defmethod" "defn")
+        idx 1]
     ;; skip :async keyword
     (when (and (< idx (len form))
                (isinstance (get form idx) Keyword))
@@ -77,7 +79,7 @@ This avoids triggering top-level code, DB connections, GPU init, etc.
           params-form (get form (inc idx))]
       (when (not (isinstance name-sym Symbol))
         (return None))
-      {"kind" "defn"
+      {"kind" kind
        "name" (unmangle (str name-sym))
        "params" (if (isinstance params-form List)
                     (_extract-params params-form)
@@ -121,7 +123,7 @@ This avoids triggering top-level code, DB connections, GPU init, etc.
       (return None))
     (let [head-str (str head)]
       (cond
-        (in head-str ["defn" "defn/a"])
+        (in head-str ["defn" "defn/a" "defmethod"])
         (_parse-defn form)
 
         (= head-str "defmacro")
@@ -266,6 +268,7 @@ This avoids triggering top-level code, DB connections, GPU init, etc.
 (defn format-surface [defs * [show-params True] [show-line False]]
   "Format a list of definition dicts as a readable table."
   (let [kind-tags {"defn" "defn"
+                   "defmethod" "meth"
                    "def" "def "
                    "defclass" "cls "
                    "class" "cls "

--- a/hyjinx/cli.hy
+++ b/hyjinx/cli.hy
@@ -223,7 +223,7 @@ Commands:
        (click.argument "target")
        (click.option "--params/--no-params" :default True :help "Show parameter names")
        (click.option "--line" :is-flag True :default False :help "Show line numbers")
-       (click.option "--kind" :type (click.Choice ["defn" "defclass" "defmacro" "setv" "def" "class"]) :multiple True :help "Filter by definition kind")]
+       (click.option "--kind" :type (click.Choice ["defn" "defmethod" "defclass" "defmacro" "setv" "def" "class"]) :multiple True :help "Filter by definition kind")]
   dir-cmd [target params line kind]
   "List the API surface of a module or file — no imports, no side effects.\n\nLike Python's dir(), but static. TARGET can be a file path (preferred)\nor a dotted module name. File paths are safest as they never trigger\nmodule side effects. Dotted names resolve via sys.path or importlib\n(may trigger imports)."
   (let [path (cond


### PR DESCRIPTION
Parse `defmethod` multimethod definitions in `hyjinx dir`:

- Add `defmethod` to form parser in `api.hy`
- Display with `meth` tag in output
- Add `defmethod` to `--kind` filter choices in CLI

Example:
```
$ hyjinx dir hyjinx/llm.hy
hyjinx/llm.hy  [67 definitions]
  meth converse(client, *, system-prompt, color, kwargs)
  meth instruct(client, *, image, echo, system-prompt, color, kwargs)
  ...
```